### PR TITLE
feat: add element enums and drag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
+# Deseigner
 
+Application Java Maven proposant une interface de maquettage de pages web inspirée de Figma.
+
+## Construction
+
+```
+mvn package
+```
+
+## Exécution
+
+```
+java -jar target/deseigner-1.0-SNAPSHOT.jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.hattane.ilias</groupId>
+    <artifactId>deseigner</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/fr/hattane/ilias/deseigner/Main.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/Main.java
@@ -1,0 +1,12 @@
+package fr.hattane.ilias.deseigner;
+
+import fr.hattane.ilias.deseigner.view.MainFrame;
+
+public class Main {
+    public static void main(String[] args) {
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            MainFrame frame = new MainFrame();
+            frame.setVisible(true);
+        });
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/ColorValue.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ColorValue.java
@@ -1,0 +1,47 @@
+package fr.hattane.ilias.deseigner.model;
+
+public class ColorValue {
+    private int red;
+    private int green;
+    private int blue;
+    private double alpha;
+
+    public ColorValue(int red, int green, int blue, double alpha) {
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.alpha = alpha;
+    }
+
+    public int getRed() {
+        return red;
+    }
+
+    public void setRed(int red) {
+        this.red = red;
+    }
+
+    public int getGreen() {
+        return green;
+    }
+
+    public void setGreen(int green) {
+        this.green = green;
+    }
+
+    public int getBlue() {
+        return blue;
+    }
+
+    public void setBlue(int blue) {
+        this.blue = blue;
+    }
+
+    public double getAlpha() {
+        return alpha;
+    }
+
+    public void setAlpha(double alpha) {
+        this.alpha = alpha;
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/DesignElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/DesignElement.java
@@ -1,0 +1,53 @@
+package fr.hattane.ilias.deseigner.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class DesignElement {
+    private long id;
+    private String name;
+    private ElementType type;
+    private int index;
+    private Dimensions dimensions;
+    private Map<String, Object> properties = new HashMap<>();
+
+    protected DesignElement(long id, String name, ElementType type, int index, Dimensions dimensions) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.index = index;
+        this.dimensions = dimensions;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ElementType getType() {
+        return type;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public Dimensions getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(Dimensions dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/Dimensions.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/Dimensions.java
@@ -1,0 +1,37 @@
+package fr.hattane.ilias.deseigner.model;
+
+public class Dimensions {
+    private int width;
+    private int height;
+    private double scale;
+
+    public Dimensions(int width, int height, double scale) {
+        this.width = width;
+        this.height = height;
+        this.scale = scale;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public double getScale() {
+        return scale;
+    }
+
+    public void setScale(double scale) {
+        this.scale = scale;
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/ElementType.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ElementType.java
@@ -1,0 +1,9 @@
+package fr.hattane.ilias.deseigner.model;
+
+/**
+ * Types d'éléments disponibles dans le modèle.
+ */
+public enum ElementType {
+    PAGE,
+    RECTANGLE
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/ModelSerializer.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ModelSerializer.java
@@ -1,0 +1,19 @@
+package fr.hattane.ilias.deseigner.model;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.Reader;
+import java.io.Writer;
+
+public class ModelSerializer {
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    public void write(ProjectModel model, Writer writer) {
+        gson.toJson(model, writer);
+    }
+
+    public ProjectModel read(Reader reader) {
+        return gson.fromJson(reader, ProjectModel.class);
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/PageElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/PageElement.java
@@ -1,0 +1,7 @@
+package fr.hattane.ilias.deseigner.model;
+
+public class PageElement extends DesignElement {
+    public PageElement(long id, String name, int index, Dimensions dimensions) {
+        super(id, name, ElementType.PAGE, index, dimensions);
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/ProjectModel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ProjectModel.java
@@ -1,0 +1,58 @@
+package fr.hattane.ilias.deseigner.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProjectModel {
+    private long id;
+    private String name;
+    private String description;
+    private Dimensions dimensions;
+    private Map<String, Object> properties = new HashMap<>();
+    private List<DesignElement> elements = new ArrayList<>();
+
+    public ProjectModel(long id, String name, String description, Dimensions dimensions) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.dimensions = dimensions;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Dimensions getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(Dimensions dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public List<DesignElement> getElements() {
+        return elements;
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/ElementView.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/ElementView.java
@@ -1,0 +1,103 @@
+package fr.hattane.ilias.deseigner.view;
+
+import fr.hattane.ilias.deseigner.model.ElementType;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/**
+ * Représentation graphique simple d'un élément sur la zone de dessin.
+ */
+public class ElementView extends JComponent {
+    private String elementName = "Élément";
+    private String elementId = "";
+    private String description = "";
+    private int zIndex = 0;
+    private Color background = Color.LIGHT_GRAY;
+    private ElementType type = ElementType.RECTANGLE;
+    private Point dragOffset;
+
+    public ElementView(int x, int y, int width, int height) {
+        setBounds(x, y, width, height);
+        setOpaque(false);
+
+        MouseAdapter adapter = new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                dragOffset = e.getPoint();
+            }
+
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if (dragOffset == null) return;
+                int newX = getX() + e.getX() - dragOffset.x;
+                int newY = getY() + e.getY() - dragOffset.y;
+                setLocation(newX, newY);
+            }
+        };
+        addMouseListener(adapter);
+        addMouseMotionListener(adapter);
+    }
+
+    public String getElementName() {
+        return elementName;
+    }
+
+    public void setElementName(String elementName) {
+        this.elementName = elementName;
+    }
+
+    public String getElementId() {
+        return elementId;
+    }
+
+    public void setElementId(String elementId) {
+        this.elementId = elementId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getZIndex() {
+        return zIndex;
+    }
+
+    public void setZIndex(int zIndex) {
+        this.zIndex = zIndex;
+        getParent().setComponentZOrder(this, zIndex);
+    }
+
+    public Color getBackgroundColor() {
+        return background;
+    }
+
+    public void setBackgroundColor(Color background) {
+        this.background = background;
+        repaint();
+    }
+
+    public ElementType getType() {
+        return type;
+    }
+
+    public void setType(ElementType type) {
+        this.type = type;
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        g2.setColor(background);
+        g2.fillRect(0, 0, getWidth(), getHeight());
+        g2.setColor(Color.BLACK);
+        g2.drawRect(0, 0, getWidth() - 1, getHeight() - 1);
+        g2.dispose();
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/MainFrame.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/MainFrame.java
@@ -1,0 +1,47 @@
+package fr.hattane.ilias.deseigner.view;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class MainFrame extends JFrame {
+    private final CardLayout cardLayout = new CardLayout();
+    private final JPanel mainPanel = new JPanel(cardLayout);
+
+    public MainFrame() {
+        super("Deseigner");
+        setUndecorated(true);
+        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+        setSize(896, 414);
+        setLocationRelativeTo(null);
+        initMenuBar();
+        initPanels();
+    }
+
+    private void initMenuBar() {
+        JMenuBar bar = new JMenuBar();
+        JMenu fileMenu = new JMenu("Fichier");
+        JMenuItem saveItem = new JMenuItem("Sauvegarder");
+        JMenuItem exportItem = new JMenuItem("Exporter HTML");
+        fileMenu.add(saveItem);
+        fileMenu.add(exportItem);
+        bar.add(fileMenu);
+        bar.add(Box.createHorizontalGlue());
+        JButton closeButton = new JButton("X");
+        closeButton.addActionListener(e -> dispose());
+        bar.add(closeButton);
+        setJMenuBar(bar);
+    }
+
+    private void initPanels() {
+        MenuPanel menuPanel = new MenuPanel(this::showEditor);
+        ProjectEditorPanel editorPanel = new ProjectEditorPanel();
+        mainPanel.add(menuPanel, "menu");
+        mainPanel.add(editorPanel, "editor");
+        add(mainPanel);
+        cardLayout.show(mainPanel, "menu");
+    }
+
+    private void showEditor() {
+        cardLayout.show(mainPanel, "editor");
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/MenuPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/MenuPanel.java
@@ -1,0 +1,20 @@
+package fr.hattane.ilias.deseigner.view;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.function.Consumer;
+
+public class MenuPanel extends JPanel {
+    public MenuPanel(Runnable startEditor) {
+        setLayout(new GridLayout(3, 1, 10, 10));
+        JButton newProject = new JButton("Créer un nouveau projet");
+        JButton editProject = new JButton("Modifier un projet");
+        JButton continueProject = new JButton("Continuer le dernier projet");
+        newProject.addActionListener(e -> startEditor.run());
+        editProject.addActionListener(e -> startEditor.run());
+        continueProject.addActionListener(e -> startEditor.run());
+        add(newProject);
+        add(editProject);
+        add(continueProject);
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/ModelCanvas.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/ModelCanvas.java
@@ -1,0 +1,87 @@
+package fr.hattane.ilias.deseigner.view;
+
+import fr.hattane.ilias.deseigner.model.ElementType;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Zone de dessin principale affichant la grille et les éléments.
+ */
+public class ModelCanvas extends JPanel {
+    private final JPopupMenu contextMenu = new JPopupMenu();
+    private final List<ElementView> elements = new ArrayList<>();
+    private final PropertyPanel propertyPanel;
+    private Point lastClick = new Point();
+    private ElementView target;
+
+    public ModelCanvas(PropertyPanel panel) {
+        this.propertyPanel = panel;
+        setBackground(Color.WHITE);
+        setLayout(null);
+        initContextMenu();
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.isPopupTrigger()) showMenu(e);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.isPopupTrigger()) showMenu(e);
+            }
+        });
+    }
+
+    private final JMenuItem editItem = new JMenuItem("Modifier l'élément");
+
+    private void initContextMenu() {
+        JMenu addMenu = new JMenu("Ajouter");
+        JMenuItem rectItem = new JMenuItem("Rectangle");
+        rectItem.addActionListener(e -> addElement(ElementType.RECTANGLE));
+        addMenu.add(rectItem);
+        contextMenu.add(addMenu);
+
+        editItem.addActionListener(e -> propertyPanel.setElement(target));
+        contextMenu.add(editItem);
+    }
+
+    private void addElement(ElementType type) {
+        ElementView el = new ElementView(lastClick.x, lastClick.y, 100, 60);
+        el.setType(type);
+        elements.add(el);
+        add(el);
+        repaint();
+    }
+
+    private ElementView findElement(Point p) {
+        for (ElementView el : elements) {
+            if (el.getBounds().contains(p)) return el;
+        }
+        return null;
+    }
+
+    private void showMenu(MouseEvent e) {
+        lastClick = e.getPoint();
+        target = findElement(lastClick);
+        editItem.setEnabled(target != null);
+        contextMenu.show(this, e.getX(), e.getY());
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        int step = 20;
+        g.setColor(new Color(230, 230, 230));
+        for (int x = 0; x < getWidth(); x += step) {
+            g.drawLine(x, 0, x, getHeight());
+        }
+        for (int y = 0; y < getHeight(); y += step) {
+            g.drawLine(0, y, getWidth(), y);
+        }
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/ProjectEditorPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/ProjectEditorPanel.java
@@ -1,0 +1,15 @@
+package fr.hattane.ilias.deseigner.view;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ProjectEditorPanel extends JPanel {
+    private final PropertyPanel propertyPanel = new PropertyPanel();
+    private final ModelCanvas canvas = new ModelCanvas(propertyPanel);
+
+    public ProjectEditorPanel() {
+        setLayout(new BorderLayout());
+        add(canvas, BorderLayout.CENTER);
+        add(propertyPanel, BorderLayout.EAST);
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/PropertyPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/PropertyPanel.java
@@ -1,0 +1,84 @@
+package fr.hattane.ilias.deseigner.view;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+
+/**
+ * Panneau affichant et éditant les propriétés de l'élément sélectionné.
+ */
+public class PropertyPanel extends JPanel {
+    private final JTextField nameField = new JTextField();
+    private final JTextField idField = new JTextField();
+    private final JTextField descField = new JTextField();
+    private final JTextField zIndexField = new JTextField();
+    private ElementView current;
+
+    public PropertyPanel() {
+        setPreferredSize(new Dimension(200, 0));
+        setLayout(new GridLayout(0, 1));
+        add(new JLabel("Nom"));
+        add(nameField);
+        add(new JLabel("Id"));
+        add(idField);
+        add(new JLabel("Description"));
+        add(descField);
+        add(new JLabel("Z-index"));
+        add(zIndexField);
+        JButton colorButton = new JButton("Couleur de fond");
+        colorButton.addActionListener(e -> chooseColor());
+        add(colorButton);
+
+        DocumentListener docListener = new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { apply(); }
+            @Override public void removeUpdate(DocumentEvent e) { apply(); }
+            @Override public void changedUpdate(DocumentEvent e) { apply(); }
+        };
+        nameField.getDocument().addDocumentListener(docListener);
+        idField.getDocument().addDocumentListener(docListener);
+        descField.getDocument().addDocumentListener(docListener);
+        zIndexField.getDocument().addDocumentListener(docListener);
+    }
+
+    /**
+     * Charge l'élément dans le panneau afin d'en modifier les propriétés.
+     */
+    public void setElement(ElementView element) {
+        this.current = element;
+        if (element == null) {
+            nameField.setText("");
+            idField.setText("");
+            descField.setText("");
+            zIndexField.setText("");
+            setBackground(null);
+            return;
+        }
+        nameField.setText(element.getElementName());
+        idField.setText(element.getElementId());
+        descField.setText(element.getDescription());
+        zIndexField.setText(String.valueOf(element.getZIndex()));
+        setBackground(element.getBackgroundColor());
+    }
+
+    private void apply() {
+        if (current == null) return;
+        current.setElementName(nameField.getText());
+        current.setElementId(idField.getText());
+        current.setDescription(descField.getText());
+        try {
+            int z = Integer.parseInt(zIndexField.getText());
+            current.setZIndex(z);
+        } catch (NumberFormatException ignored) {
+        }
+    }
+
+    private void chooseColor() {
+        if (current == null) return;
+        Color c = JColorChooser.showDialog(this, "Couleur de fond", current.getBackgroundColor());
+        if (c != null) {
+            current.setBackgroundColor(c);
+            setBackground(c);
+        }
+    }
+}

--- a/src/main/resources/model.json
+++ b/src/main/resources/model.json
@@ -1,0 +1,41 @@
+{
+  "model": {
+    "id": 1,
+    "name": "Site 1",
+    "description": "Site de commerce.",
+    "dimensions": {
+      "width": 500,
+      "height": 500,
+      "scale": 1.2
+    },
+    "properties": {
+      "background-color": {
+        "red": 120,
+        "green": 120,
+        "blue": 120,
+        "alpha": 0.9
+      }
+    },
+    "elements": [
+      {
+        "id": 2,
+        "name": "Page 1",
+        "type": "PAGE",
+        "index": 1,
+        "dimensions": {
+          "width": 500,
+          "height": 500,
+          "scale": 1.2
+        },
+        "properties": {
+          "background-color": {
+            "red": 255,
+            "green": 255,
+            "blue": 255,
+            "alpha": 1.0
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- model element types with `ElementType` enum and property maps
- allow adding rectangle elements from context menu and dragging them around
- update sample model JSON for new structure

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db2962dc83238f2f94c0f0fc9c94