### PR TITLE
Amélioration de l'éditeur avec bouton, bordures et ombres

### DIFF
--- a/src/main/java/fr/hattane/ilias/deseigner/model/ElementTypes.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ElementTypes.java
@@ -5,5 +5,7 @@ package fr.hattane.ilias.deseigner.model;
  */
 public enum ElementTypes {
     PAGE,
-    RECTANGLE
+    RECTANGLE,
+    TEXT,
+    BUTTON
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/model/ProjectModel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/ProjectModel.java
@@ -6,27 +6,24 @@ import java.util.List;
 import java.util.Map;
 
 import fr.hattane.ilias.deseigner.model.elements.DesignElement;
-import fr.hattane.ilias.deseigner.model.utils.Dimensions;
 
 public class ProjectModel {
-	
-	public static long ids = 0;
-	
+
+    private static long ids = 0;
+
     private long id;
     private String name;
     private String description;
-    
-    private Dimensions dimensions;
-    private float scale = 1.0f;
-    
-    private Map<String, Object> properties = new HashMap<>();
-    private List<DesignElement> elements = new ArrayList<>();
 
-    public ProjectModel(String name, String description, Dimensions dimensions) {
+    private float scale = 1.0f;
+
+    private final Map<String, Object> properties = new HashMap<>();
+    private final List<DesignElement> elements = new ArrayList<>();
+
+    public ProjectModel(String name, String description) {
         this.id = ++ids;
         this.name = name;
         this.description = description;
-        this.dimensions = dimensions;
     }
 
     public long getId() {
@@ -49,14 +46,6 @@ public class ProjectModel {
         this.description = description;
     }
 
-    public Dimensions getDimensions() {
-        return dimensions;
-    }
-
-    public void setDimensions(Dimensions dimensions) {
-        this.dimensions = dimensions;
-    }
-
     public Map<String, Object> getProperties() {
         return properties;
     }
@@ -65,11 +54,11 @@ public class ProjectModel {
         return elements;
     }
 
-	public float getScale() {
-		return scale;
-	}
+    public float getScale() {
+        return scale;
+    }
 
-	public void setScale(float scale) {
-		this.scale = scale;
-	}
+    public void setScale(float scale) {
+        this.scale = scale;
+    }
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/ButtonElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/ButtonElement.java
@@ -1,0 +1,23 @@
+package fr.hattane.ilias.deseigner.model.elements.types;
+
+import fr.hattane.ilias.deseigner.model.ElementTypes;
+import fr.hattane.ilias.deseigner.model.utils.ColorValue;
+
+/**
+ * Modèle représentant un bouton (rectangle avec texte).
+ */
+public class ButtonElement extends TextElement {
+
+    public ButtonElement(String name, int x, int y, int width, int height) {
+        super(name, x, y, width, height, ElementTypes.BUTTON);
+        // Couleur de fond chaude et texte contrasté
+        setBackground(new ColorValue(240, 173, 78));
+        setTextColor(new ColorValue(255, 255, 255));
+        // Petite ombre noire par défaut
+        setShadowEnabled(true);
+        setShadowColor(new ColorValue(0, 0, 0, 0.5f));
+        setShadowOffsetX(2);
+        setShadowOffsetY(2);
+        setShadowBlur(4);
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/RectangleElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/RectangleElement.java
@@ -1,7 +1,130 @@
 package fr.hattane.ilias.deseigner.model.elements.types;
 
+import fr.hattane.ilias.deseigner.model.ElementTypes;
 import fr.hattane.ilias.deseigner.model.elements.DesignElement;
+import fr.hattane.ilias.deseigner.model.utils.ColorValue;
+import fr.hattane.ilias.deseigner.model.utils.Dimensions;
 
+/**
+ * Modèle représentant un rectangle simple.
+ */
 public class RectangleElement extends DesignElement {
 
+    private int x;
+    private int y;
+    private ColorValue background = new ColorValue(200, 200, 200);
+    private ColorValue borderColor = new ColorValue(0, 0, 0);
+    private int borderWidth = 1;
+    private boolean shadow = false;
+    private ColorValue shadowColor = new ColorValue(0, 0, 0, 0.5f);
+    private int shadowOffsetX = 2;
+    private int shadowOffsetY = 2;
+    private int shadowBlur = 4;
+
+    public RectangleElement(String name, int x, int y, int width, int height) {
+        this(name, x, y, width, height, ElementTypes.RECTANGLE);
+    }
+
+    protected RectangleElement(String name, int x, int y, int width, int height, ElementTypes type) {
+        super(name, type, 0, new Dimensions(width, height));
+        this.x = x;
+        this.y = y;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public int getWidth() {
+        return getDimensions().getWidth();
+    }
+
+    public void setWidth(int width) {
+        getDimensions().setWidth(width);
+    }
+
+    public int getHeight() {
+        return getDimensions().getHeight();
+    }
+
+    public void setHeight(int height) {
+        getDimensions().setHeight(height);
+    }
+
+    public ColorValue getBackground() {
+        return background;
+    }
+
+    public void setBackground(ColorValue background) {
+        this.background = background;
+    }
+
+    public ColorValue getBorderColor() {
+        return borderColor;
+    }
+
+    public void setBorderColor(ColorValue borderColor) {
+        this.borderColor = borderColor;
+    }
+
+    public int getBorderWidth() {
+        return borderWidth;
+    }
+
+    public void setBorderWidth(int borderWidth) {
+        this.borderWidth = borderWidth;
+    }
+
+    public boolean isShadowEnabled() {
+        return shadow;
+    }
+
+    public void setShadowEnabled(boolean shadow) {
+        this.shadow = shadow;
+    }
+
+    public ColorValue getShadowColor() {
+        return shadowColor;
+    }
+
+    public void setShadowColor(ColorValue shadowColor) {
+        this.shadowColor = shadowColor;
+    }
+
+    public int getShadowOffsetX() {
+        return shadowOffsetX;
+    }
+
+    public void setShadowOffsetX(int shadowOffsetX) {
+        this.shadowOffsetX = shadowOffsetX;
+    }
+
+    public int getShadowOffsetY() {
+        return shadowOffsetY;
+    }
+
+    public void setShadowOffsetY(int shadowOffsetY) {
+        this.shadowOffsetY = shadowOffsetY;
+    }
+
+    public int getShadowBlur() {
+        return shadowBlur;
+    }
+
+    public void setShadowBlur(int shadowBlur) {
+        this.shadowBlur = shadowBlur;
+    }
 }
+

--- a/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/TextElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/TextElement.java
@@ -1,0 +1,58 @@
+package fr.hattane.ilias.deseigner.model.elements.types;
+
+import fr.hattane.ilias.deseigner.model.ElementTypes;
+import fr.hattane.ilias.deseigner.model.utils.ColorValue;
+
+/**
+ * Modèle représentant une zone de texte avec propriétés de police.
+ */
+public class TextElement extends RectangleElement {
+
+    public enum TextAlignment { LEFT, CENTER, RIGHT }
+
+    private String font = "SansSerif";
+    private int fontSize = 14;
+    private ColorValue textColor = new ColorValue(0, 0, 0);
+    private TextAlignment alignment = TextAlignment.LEFT;
+
+    public TextElement(String name, int x, int y, int width, int height) {
+        this(name, x, y, width, height, ElementTypes.TEXT);
+    }
+
+    protected TextElement(String name, int x, int y, int width, int height, ElementTypes type) {
+        super(name, x, y, width, height, type);
+        setBackground(new ColorValue(0, 0, 0, 0));
+    }
+
+    public String getFont() {
+        return font;
+    }
+
+    public void setFont(String font) {
+        this.font = font;
+    }
+
+    public int getFontSize() {
+        return fontSize;
+    }
+
+    public void setFontSize(int fontSize) {
+        this.fontSize = fontSize;
+    }
+
+    public ColorValue getTextColor() {
+        return textColor;
+    }
+
+    public void setTextColor(ColorValue textColor) {
+        this.textColor = textColor;
+    }
+
+    public TextAlignment getAlignment() {
+        return alignment;
+    }
+
+    public void setAlignment(TextAlignment alignment) {
+        this.alignment = alignment;
+    }
+}

--- a/src/main/java/fr/hattane/ilias/deseigner/view/frames/MainFrame.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/frames/MainFrame.java
@@ -9,16 +9,24 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JFileChooser;
+
+import fr.hattane.ilias.deseigner.model.ProjectModel;
+import fr.hattane.ilias.deseigner.model.serializers.ModelSerializer;
 
 import fr.hattane.ilias.deseigner.view.panels.MenuPanel;
 import fr.hattane.ilias.deseigner.view.panels.ProjectEditorPanel;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 
 public class MainFrame extends JFrame {
 	
 	private static final long serialVersionUID = -4811040262377922922L;
 	
-	private final CardLayout cardLayout = new CardLayout();
+    private final CardLayout cardLayout = new CardLayout();
     private final JPanel mainPanel = new JPanel(cardLayout);
+    private final ProjectEditorPanel editorPanel = new ProjectEditorPanel();
 
     public MainFrame() {
         super("Deseigner");
@@ -33,8 +41,10 @@ public class MainFrame extends JFrame {
     private void initMenuBar() {
         JMenuBar bar = new JMenuBar();
         JMenu fileMenu = new JMenu("Fichier");
+        JMenuItem openItem = new JMenuItem("Ouvrir");
         JMenuItem saveItem = new JMenuItem("Sauvegarder");
         JMenuItem exportItem = new JMenuItem("Exporter HTML");
+        fileMenu.add(openItem);
         fileMenu.add(saveItem);
         fileMenu.add(exportItem);
         bar.add(fileMenu);
@@ -43,18 +53,42 @@ public class MainFrame extends JFrame {
         closeButton.addActionListener(e -> dispose());
         bar.add(closeButton);
         setJMenuBar(bar);
+
+        openItem.addActionListener(e -> {
+            JFileChooser chooser = new JFileChooser();
+            if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+                try (FileReader reader = new FileReader(chooser.getSelectedFile())) {
+                    ProjectModel model = new ModelSerializer().read(reader);
+                    startEditor(model);
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        });
+
+        saveItem.addActionListener(e -> {
+            if (editorPanel.getProject() == null) return;
+            JFileChooser chooser = new JFileChooser();
+            if (chooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
+                try (FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
+                    new ModelSerializer().write(editorPanel.getProject(), writer);
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        });
     }
 
     private void initPanels() {
-        MenuPanel menuPanel = new MenuPanel(this::showEditor);
-        ProjectEditorPanel editorPanel = new ProjectEditorPanel();
+        MenuPanel menuPanel = new MenuPanel(this::startEditor);
         mainPanel.add(menuPanel, "menu");
         mainPanel.add(editorPanel, "editor");
         add(mainPanel);
         cardLayout.show(mainPanel, "menu");
     }
 
-    private void showEditor() {
+    private void startEditor(ProjectModel model) {
+        editorPanel.setProject(model);
         cardLayout.show(mainPanel, "editor");
     }
     

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/MenuPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/MenuPanel.java
@@ -1,25 +1,66 @@
 package fr.hattane.ilias.deseigner.view.panels;
 
-import java.awt.GridLayout;
+import fr.hattane.ilias.deseigner.model.ProjectModel;
+import fr.hattane.ilias.deseigner.model.serializers.ModelSerializer;
 
-import javax.swing.JButton;
-import javax.swing.JPanel;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.function.Consumer;
 
 public class MenuPanel extends JPanel {
-	
-	private static final long serialVersionUID = -6046308218369357949L;
-	
-	public MenuPanel(Runnable startEditor) {
-        setLayout(new GridLayout(3, 1, 10, 10));
+
+    private static final long serialVersionUID = -6046308218369357949L;
+
+    public MenuPanel(Consumer<ProjectModel> startEditor) {
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setBorder(new EmptyBorder(40, 40, 40, 40));
+
+        JLabel title = new JLabel("Deseigner");
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 24f));
+        title.setAlignmentX(Component.CENTER_ALIGNMENT);
+
         JButton newProject = new JButton("Créer un nouveau projet");
         JButton editProject = new JButton("Modifier un projet");
         JButton continueProject = new JButton("Continuer le dernier projet");
-        newProject.addActionListener(e -> startEditor.run());
-        editProject.addActionListener(e -> startEditor.run());
-        continueProject.addActionListener(e -> startEditor.run());
+
+        newProject.setAlignmentX(Component.CENTER_ALIGNMENT);
+        editProject.setAlignmentX(Component.CENTER_ALIGNMENT);
+        continueProject.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        newProject.addActionListener(e -> {
+            JTextField name = new JTextField();
+            JTextField desc = new JTextField();
+            Object[] message = {"Nom", name, "Description", desc};
+            int option = JOptionPane.showConfirmDialog(this, message, "Nouveau projet", JOptionPane.OK_CANCEL_OPTION);
+            if (option == JOptionPane.OK_OPTION) {
+                ProjectModel model = new ProjectModel(name.getText(), desc.getText());
+                startEditor.accept(model);
+            }
+        });
+
+        editProject.addActionListener(e -> {
+            JFileChooser chooser = new JFileChooser();
+            if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+                try (FileReader reader = new FileReader(chooser.getSelectedFile())) {
+                    ProjectModel model = new ModelSerializer().read(reader);
+                    startEditor.accept(model);
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        });
+        continueProject.addActionListener(e -> startEditor.accept(new ProjectModel("Projet", "")));
+
+        add(title);
+        add(Box.createVerticalStrut(30));
         add(newProject);
+        add(Box.createVerticalStrut(10));
         add(editProject);
+        add(Box.createVerticalStrut(10));
         add(continueProject);
     }
-	
+
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/ProjectEditorPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/ProjectEditorPanel.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 
 import javax.swing.JPanel;
 
+import fr.hattane.ilias.deseigner.model.ProjectModel;
 import fr.hattane.ilias.deseigner.view.panels.editor.ModelCanvas;
 import fr.hattane.ilias.deseigner.view.panels.editor.PropertyPanel;
 
@@ -11,13 +12,29 @@ public class ProjectEditorPanel extends JPanel {
 	
 	private static final long serialVersionUID = 975617998984467670L;
 	
-	private final PropertyPanel propertyPanel = new PropertyPanel();
-    private final ModelCanvas canvas = new ModelCanvas(propertyPanel);
+    private final PropertyPanel propertyPanel = new PropertyPanel();
+    private ModelCanvas canvas;
+    private ProjectModel project;
 
     public ProjectEditorPanel() {
         setLayout(new BorderLayout());
-        add(canvas, BorderLayout.CENTER);
+        propertyPanel.setVisible(false);
         add(propertyPanel, BorderLayout.EAST);
     }
-    
+
+    public void setProject(ProjectModel project) {
+        this.project = project;
+        if (canvas != null) {
+            remove(canvas);
+        }
+        canvas = new ModelCanvas(propertyPanel, project);
+        add(canvas, BorderLayout.CENTER);
+        revalidate();
+        repaint();
+    }
+
+    public ProjectModel getProject() {
+        return project;
+    }
+
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ElementView.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ElementView.java
@@ -1,57 +1,124 @@
 package fr.hattane.ilias.deseigner.view.panels.editor;
 
 import fr.hattane.ilias.deseigner.model.ElementTypes;
+import fr.hattane.ilias.deseigner.model.elements.types.RectangleElement;
+import fr.hattane.ilias.deseigner.model.elements.types.TextElement;
+import fr.hattane.ilias.deseigner.model.utils.ColorValue;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 
 /**
- * Représentation graphique simple d'un élément sur la zone de dessin.
+ * Représentation graphique d'un élément rectangle sur la zone de dessin.
  */
 public class ElementView extends JComponent {
-	
-	private static final long serialVersionUID = 3548738642211048029L;
-	
-	private String elementName = "Élément";
+
+    private static final long serialVersionUID = 3548738642211048029L;
+
+    private final RectangleElement model;
+    private final ModelCanvas canvas;
     private String elementId = "";
     private String description = "";
     private int zIndex = 0;
-    private Color background = Color.LIGHT_GRAY;
-    private ElementTypes type = ElementTypes.RECTANGLE;
     private Point dragOffset;
+    private boolean selected;
+    private ElementTypes type = ElementTypes.RECTANGLE;
+    private ResizeDirection resizeDir = ResizeDirection.NONE;
 
-    public ElementView(int x, int y, int width, int height) {
-    	
-        setBounds(x, y, width, height);
+    private static final int RESIZE_MARGIN = 5;
+
+    private enum ResizeDirection { NONE, NORTH, SOUTH, EAST, WEST }
+
+    public ElementView(ModelCanvas canvas, RectangleElement model) {
+        this.canvas = canvas;
+        this.model = model;
         setOpaque(false);
+        setBounds(0,0,0,0);
+        canvas.updateElementView(this);
 
         MouseAdapter adapter = new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                dragOffset = e.getPoint();
+                if (resizeDir != ResizeDirection.NONE) {
+                    dragOffset = e.getPoint();
+                } else {
+                    dragOffset = e.getPoint();
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                dragOffset = null;
+                resizeDir = ResizeDirection.NONE;
+                setCursor(Cursor.getDefaultCursor());
             }
 
             @Override
             public void mouseDragged(MouseEvent e) {
                 if (dragOffset == null) return;
-                int newX = getX() + e.getX() - dragOffset.x;
-                int newY = getY() + e.getY() - dragOffset.y;
-                setLocation(newX, newY);
+                float scale = canvas.getScale();
+                int dx = Math.round((e.getX() - dragOffset.x) / scale);
+                int dy = Math.round((e.getY() - dragOffset.y) / scale);
+                if (resizeDir == ResizeDirection.EAST) {
+                    model.setWidth(Math.max(1, model.getWidth() + dx));
+                } else if (resizeDir == ResizeDirection.WEST) {
+                    int newWidth = Math.max(1, model.getWidth() - dx);
+                    model.setX(model.getX() + dx);
+                    model.setWidth(newWidth);
+                } else if (resizeDir == ResizeDirection.SOUTH) {
+                    model.setHeight(Math.max(1, model.getHeight() + dy));
+                } else if (resizeDir == ResizeDirection.NORTH) {
+                    int newHeight = Math.max(1, model.getHeight() - dy);
+                    model.setY(model.getY() + dy);
+                    model.setHeight(newHeight);
+                } else {
+                    model.setX(model.getX() + dx);
+                    model.setY(model.getY() + dy);
+                }
+                dragOffset = e.getPoint();
+                canvas.updateElementView(ElementView.this);
+                canvas.refreshPropertyPanel();
             }
         };
         addMouseListener(adapter);
         addMouseMotionListener(adapter);
-        
+        addMouseMotionListener(new MouseMotionAdapter() {
+            @Override
+            public void mouseMoved(MouseEvent e) {
+                if (!selected) return;
+                if (e.getX() < RESIZE_MARGIN) {
+                    resizeDir = ResizeDirection.WEST;
+                    setCursor(Cursor.getPredefinedCursor(Cursor.W_RESIZE_CURSOR));
+                } else if (e.getX() > getWidth() - RESIZE_MARGIN) {
+                    resizeDir = ResizeDirection.EAST;
+                    setCursor(Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR));
+                } else if (e.getY() < RESIZE_MARGIN) {
+                    resizeDir = ResizeDirection.NORTH;
+                    setCursor(Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR));
+                } else if (e.getY() > getHeight() - RESIZE_MARGIN) {
+                    resizeDir = ResizeDirection.SOUTH;
+                    setCursor(Cursor.getPredefinedCursor(Cursor.S_RESIZE_CURSOR));
+                } else {
+                    resizeDir = ResizeDirection.NONE;
+                    setCursor(Cursor.getDefaultCursor());
+                }
+            }
+        });
+    }
+
+    public RectangleElement getModel() {
+        return model;
     }
 
     public String getElementName() {
-        return elementName;
+        return model.getName();
     }
 
     public void setElementName(String elementName) {
-        this.elementName = elementName;
+        model.setName(elementName);
     }
 
     public String getElementId() {
@@ -76,15 +143,18 @@ public class ElementView extends JComponent {
 
     public void setZIndex(int zIndex) {
         this.zIndex = zIndex;
-        getParent().setComponentZOrder(this, zIndex);
+        if (getParent() != null) {
+            getParent().setComponentZOrder(this, zIndex);
+        }
     }
 
     public Color getBackgroundColor() {
-        return background;
+        ColorValue cv = model.getBackground();
+        return new Color(cv.getRed(), cv.getGreen(), cv.getBlue(), Math.round(cv.getAlpha() * 255));
     }
 
     public void setBackgroundColor(Color background) {
-        this.background = background;
+        model.setBackground(new ColorValue(background.getRed(), background.getGreen(), background.getBlue(), background.getAlpha() / 255f));
         repaint();
     }
 
@@ -96,14 +166,53 @@ public class ElementView extends JComponent {
         this.type = type;
     }
 
+    public void setSelected(boolean selected) {
+        this.selected = selected;
+        repaint();
+    }
+
+    public ModelCanvas getCanvas() {
+        return canvas;
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
         Graphics2D g2 = (Graphics2D) g.create();
-        g2.setColor(background);
+        if (model.isShadowEnabled()) {
+            ColorValue sc = model.getShadowColor();
+            g2.setColor(new Color(sc.getRed(), sc.getGreen(), sc.getBlue(), Math.round(sc.getAlpha() * 255)));
+            g2.fillRoundRect(model.getShadowOffsetX(), model.getShadowOffsetY(), getWidth(), getHeight(), model.getShadowBlur(), model.getShadowBlur());
+        }
+        g2.setColor(getBackgroundColor());
         g2.fillRect(0, 0, getWidth(), getHeight());
-        g2.setColor(Color.BLACK);
+        ColorValue bc = model.getBorderColor();
+        Color border = new Color(bc.getRed(), bc.getGreen(), bc.getBlue());
+        g2.setColor(selected ? new Color(0, 120, 215) : border);
+        g2.setStroke(new BasicStroke(model.getBorderWidth()));
         g2.drawRect(0, 0, getWidth() - 1, getHeight() - 1);
+
+        if ((type == ElementTypes.TEXT || type == ElementTypes.BUTTON) && model instanceof TextElement) {
+            TextElement t = (TextElement) model;
+            ColorValue tc = t.getTextColor();
+            g2.setColor(new Color(tc.getRed(), tc.getGreen(), tc.getBlue()));
+            g2.setFont(new Font(t.getFont(), Font.PLAIN, t.getFontSize()));
+            FontMetrics fm = g2.getFontMetrics();
+            String text = model.getName();
+            int textWidth = fm.stringWidth(text);
+            int x;
+            switch (t.getAlignment()) {
+                case CENTER:
+                    x = (getWidth() - textWidth) / 2;
+                    break;
+                case RIGHT:
+                    x = getWidth() - textWidth - 5;
+                    break;
+                default:
+                    x = 5;
+            }
+            int y = (getHeight() + fm.getAscent() - fm.getDescent()) / 2;
+            g2.drawString(text, x, y);
+        }
         g2.dispose();
     }
-    
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ModelCanvas.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ModelCanvas.java
@@ -1,11 +1,17 @@
 package fr.hattane.ilias.deseigner.view.panels.editor;
 
 import fr.hattane.ilias.deseigner.model.ElementTypes;
+import fr.hattane.ilias.deseigner.model.ProjectModel;
+import fr.hattane.ilias.deseigner.model.elements.DesignElement;
+import fr.hattane.ilias.deseigner.model.elements.types.RectangleElement;
+import fr.hattane.ilias.deseigner.model.elements.types.TextElement;
+import fr.hattane.ilias.deseigner.model.elements.types.ButtonElement;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,31 +19,90 @@ import java.util.List;
  * Zone de dessin principale affichant la grille et les éléments.
  */
 public class ModelCanvas extends JPanel {
-	
-	private static final long serialVersionUID = 1465933412461813546L;
-	
-	private final JPopupMenu contextMenu = new JPopupMenu();
+
+    private static final long serialVersionUID = 1465933412461813546L;
+
+    private final JPopupMenu contextMenu = new JPopupMenu();
     private final List<ElementView> elements = new ArrayList<>();
     private final PropertyPanel propertyPanel;
+    private final ProjectModel project;
     private Point lastClick = new Point();
     private ElementView target;
+    private ElementView selected;
+    private Point panStart;
+    private float offsetX = 0;
+    private float offsetY = 0;
 
-    public ModelCanvas(PropertyPanel panel) {
+    public ModelCanvas(PropertyPanel panel, ProjectModel project) {
         this.propertyPanel = panel;
+        this.project = project;
         setBackground(Color.WHITE);
         setLayout(null);
         initContextMenu();
-        addMouseListener(new MouseAdapter() {
+        for (DesignElement el : project.getElements()) {
+            if (el instanceof RectangleElement) {
+                ElementView view = new ElementView(this, (RectangleElement) el);
+                view.setType(el.getType());
+                elements.add(view);
+                add(view);
+                updateElementView(view);
+            }
+        }
+
+        MouseAdapter mouse = new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                if (e.isPopupTrigger()) showMenu(e);
+                if (SwingUtilities.isRightMouseButton(e)) {
+                    showMenu(e);
+                } else if (SwingUtilities.isMiddleMouseButton(e)) {
+                    panStart = e.getPoint();
+                } else if (SwingUtilities.isLeftMouseButton(e)) {
+                    selectElement(findElement(toModel(e.getPoint())));
+                }
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                if (e.isPopupTrigger()) showMenu(e);
+                if (SwingUtilities.isRightMouseButton(e)) showMenu(e);
+                if (SwingUtilities.isMiddleMouseButton(e)) panStart = null;
             }
-        });
+
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if (panStart != null) {
+                    float scale = project.getScale();
+                    int dx = e.getX() - panStart.x;
+                    int dy = e.getY() - panStart.y;
+                    offsetX += dx / scale;
+                    offsetY += dy / scale;
+                    panStart = e.getPoint();
+                    updateElementViews();
+                    repaint();
+                }
+            }
+
+            @Override
+            public void mouseWheelMoved(MouseWheelEvent e) {
+                float old = project.getScale();
+                float scale = old;
+                if (e.getWheelRotation() < 0) {
+                    scale *= 1.1f;
+                } else {
+                    scale /= 1.1f;
+                }
+                if (scale < 0.1f) scale = 0.1f;
+                if (scale > 5f) scale = 5f;
+                float factor = scale / old;
+                offsetX = offsetX * factor;
+                offsetY = offsetY * factor;
+                project.setScale(scale);
+                updateElementViews();
+                repaint();
+            }
+        };
+        addMouseListener(mouse);
+        addMouseMotionListener(mouse);
+        addMouseWheelListener(mouse);
     }
 
     private final JMenuItem editItem = new JMenuItem("Modifier l'élément");
@@ -47,45 +112,113 @@ public class ModelCanvas extends JPanel {
         JMenuItem rectItem = new JMenuItem("Rectangle");
         rectItem.addActionListener(e -> addElement(ElementTypes.RECTANGLE));
         addMenu.add(rectItem);
+        JMenuItem textItem = new JMenuItem("Zone de texte");
+        textItem.addActionListener(e -> addElement(ElementTypes.TEXT));
+        addMenu.add(textItem);
+        JMenuItem btnItem = new JMenuItem("Bouton");
+        btnItem.addActionListener(e -> addElement(ElementTypes.BUTTON));
+        addMenu.add(btnItem);
         contextMenu.add(addMenu);
 
         editItem.addActionListener(e -> propertyPanel.setElement(target));
         contextMenu.add(editItem);
     }
 
+    private Point toModel(Point p) {
+        float scale = project.getScale();
+        int x = Math.round(p.x / scale - offsetX);
+        int y = Math.round(p.y / scale - offsetY);
+        return new Point(x, y);
+    }
+
     private void addElement(ElementTypes type) {
-        ElementView el = new ElementView(lastClick.x, lastClick.y, 100, 60);
+        RectangleElement rect;
+        if (type == ElementTypes.TEXT) {
+            rect = new TextElement("Texte", lastClick.x, lastClick.y, 100, 40);
+        } else if (type == ElementTypes.BUTTON) {
+            rect = new ButtonElement("Bouton", lastClick.x, lastClick.y, 120, 40);
+        } else {
+            rect = new RectangleElement("Rectangle", lastClick.x, lastClick.y, 100, 60);
+        }
+        project.getElements().add(rect);
+        ElementView el = new ElementView(this, rect);
         el.setType(type);
         elements.add(el);
         add(el);
-        repaint();
+        selectElement(el);
+        updateElementView(el);
     }
 
     private ElementView findElement(Point p) {
         for (ElementView el : elements) {
-            if (el.getBounds().contains(p)) return el;
+            Rectangle r = new Rectangle(el.getModel().getX(), el.getModel().getY(), el.getModel().getWidth(), el.getModel().getHeight());
+            if (r.contains(p)) return el;
         }
         return null;
     }
 
     private void showMenu(MouseEvent e) {
-        lastClick = e.getPoint();
+        lastClick = toModel(e.getPoint());
         target = findElement(lastClick);
         editItem.setEnabled(target != null);
         contextMenu.show(this, e.getX(), e.getY());
     }
 
+    public void updateElementView(ElementView el) {
+        RectangleElement m = el.getModel();
+        float scale = project.getScale();
+        int x = Math.round((m.getX() + offsetX) * scale);
+        int y = Math.round((m.getY() + offsetY) * scale);
+        int w = Math.round(m.getWidth() * scale);
+        int h = Math.round(m.getHeight() * scale);
+        el.setBounds(x, y, w, h);
+        el.repaint();
+    }
+
+    private void updateElementViews() {
+        for (ElementView el : elements) {
+            updateElementView(el);
+        }
+    }
+
+    private void selectElement(ElementView el) {
+        if (selected != null) selected.setSelected(false);
+        selected = el;
+        if (el != null) {
+            el.setSelected(true);
+            propertyPanel.setElement(el);
+        } else {
+            propertyPanel.setElement(null);
+        }
+    }
+
+    public void refreshPropertyPanel() {
+        propertyPanel.refresh();
+    }
+
+    public float getScale() {
+        return project.getScale();
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
-        int step = 20;
-        g.setColor(new Color(230, 230, 230));
-        for (int x = 0; x < getWidth(); x += step) {
-            g.drawLine(x, 0, x, getHeight());
+        Graphics2D g2 = (Graphics2D) g;
+        float scale = project.getScale();
+        int step = Math.round(20 * scale);
+        if (step < 1) step = 1;
+        g2.setColor(new Color(230, 230, 230));
+        int width = getWidth();
+        int height = getHeight();
+        int startX = Math.round((offsetX * scale) % step);
+        if (startX > 0) startX -= step;
+        for (int x = startX; x < width; x += step) {
+            g2.drawLine(x, 0, x, height);
         }
-        for (int y = 0; y < getHeight(); y += step) {
-            g.drawLine(0, y, getWidth(), y);
+        int startY = Math.round((offsetY * scale) % step);
+        if (startY > 0) startY -= step;
+        for (int y = startY; y < height; y += step) {
+            g2.drawLine(0, y, width, y);
         }
     }
-    
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/PropertyPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/PropertyPanel.java
@@ -1,6 +1,10 @@
 package fr.hattane.ilias.deseigner.view.panels.editor;
 
+import fr.hattane.ilias.deseigner.model.ElementTypes;
+import fr.hattane.ilias.deseigner.model.elements.types.TextElement;
+
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.*;
@@ -12,26 +16,73 @@ public class PropertyPanel extends JPanel {
 	
 	private static final long serialVersionUID = -5823019595713087538L;
 	
-	private final JTextField nameField = new JTextField();
+        private final JTextField nameField = new JTextField();
     private final JTextField idField = new JTextField();
     private final JTextField descField = new JTextField();
     private final JTextField zIndexField = new JTextField();
+    private final JTextField widthField = new JTextField();
+    private final JTextField heightField = new JTextField();
+    private final JTextField borderWidthField = new JTextField();
+    private final JCheckBox shadowEnableBox = new JCheckBox("Ombre");
+    private final JTextField shadowOffsetXField = new JTextField();
+    private final JTextField shadowOffsetYField = new JTextField();
+    private final JTextField shadowBlurField = new JTextField();
+    private final JButton shadowColorButton = new JButton("Couleur ombre");
+    private final JComboBox<String> fontBox = new JComboBox<>(GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames());
+    private final JTextField textSizeField = new JTextField();
+    private final JComboBox<TextElement.TextAlignment> alignBox = new JComboBox<>(TextElement.TextAlignment.values());
+    private final JButton textColorButton = new JButton("Couleur texte");
+    private final JPanel textOptions = new JPanel();
     private ElementView current;
 
     public PropertyPanel() {
-        setPreferredSize(new Dimension(200, 0));
-        setLayout(new GridLayout(0, 1));
-        add(new JLabel("Nom"));
-        add(nameField);
-        add(new JLabel("Id"));
-        add(idField);
-        add(new JLabel("Description"));
-        add(descField);
-        add(new JLabel("Z-index"));
-        add(zIndexField);
+        setPreferredSize(new Dimension(220, 0));
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setBorder(new EmptyBorder(10,10,10,10));
+
+        addLabeledField("Nom", nameField);
+        addLabeledField("Id", idField);
+        addLabeledField("Description", descField);
+        addLabeledField("Z-index", zIndexField);
+        addLabeledField("Largeur", widthField);
+        addLabeledField("Hauteur", heightField);
+        addLabeledField("Bordure", borderWidthField);
+
         JButton colorButton = new JButton("Couleur de fond");
         colorButton.addActionListener(e -> chooseColor());
         add(colorButton);
+        add(Box.createVerticalStrut(8));
+        JButton borderButton = new JButton("Couleur bordure");
+        borderButton.addActionListener(e -> chooseBorderColor());
+        add(borderButton);
+
+        add(Box.createVerticalStrut(8));
+        shadowEnableBox.addActionListener(e -> apply());
+        add(shadowEnableBox);
+        addLabeledField("Décalage X", shadowOffsetXField);
+        addLabeledField("Décalage Y", shadowOffsetYField);
+        addLabeledField("Flou", shadowBlurField);
+        shadowColorButton.addActionListener(e -> chooseShadowColor());
+        add(shadowColorButton);
+
+        textOptions.setLayout(new BoxLayout(textOptions, BoxLayout.Y_AXIS));
+        textOptions.add(Box.createVerticalStrut(8));
+        textOptions.add(new JLabel("Police"));
+        textOptions.add(fontBox);
+        fontBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, fontBox.getPreferredSize().height));
+        textOptions.add(Box.createVerticalStrut(8));
+        textOptions.add(new JLabel("Taille texte"));
+        textOptions.add(textSizeField);
+        textSizeField.setMaximumSize(new Dimension(Integer.MAX_VALUE, textSizeField.getPreferredSize().height));
+        textOptions.add(Box.createVerticalStrut(8));
+        textOptions.add(new JLabel("Alignement"));
+        textOptions.add(alignBox);
+        alignBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, alignBox.getPreferredSize().height));
+        textOptions.add(Box.createVerticalStrut(8));
+        textColorButton.addActionListener(e -> chooseTextColor());
+        textOptions.add(textColorButton);
+        add(textOptions);
+        textOptions.setVisible(false);
 
         DocumentListener docListener = new DocumentListener() {
             @Override public void insertUpdate(DocumentEvent e) { apply(); }
@@ -42,6 +93,22 @@ public class PropertyPanel extends JPanel {
         idField.getDocument().addDocumentListener(docListener);
         descField.getDocument().addDocumentListener(docListener);
         zIndexField.getDocument().addDocumentListener(docListener);
+        widthField.getDocument().addDocumentListener(docListener);
+        heightField.getDocument().addDocumentListener(docListener);
+        borderWidthField.getDocument().addDocumentListener(docListener);
+        shadowOffsetXField.getDocument().addDocumentListener(docListener);
+        shadowOffsetYField.getDocument().addDocumentListener(docListener);
+        shadowBlurField.getDocument().addDocumentListener(docListener);
+        textSizeField.getDocument().addDocumentListener(docListener);
+        fontBox.addActionListener(e -> apply());
+        alignBox.addActionListener(e -> apply());
+    }
+
+    private void addLabeledField(String label, JTextField field) {
+        add(new JLabel(label));
+        add(field);
+        field.setMaximumSize(new Dimension(Integer.MAX_VALUE, field.getPreferredSize().height));
+        add(Box.createVerticalStrut(8));
     }
 
     /**
@@ -49,19 +116,48 @@ public class PropertyPanel extends JPanel {
      */
     public void setElement(ElementView element) {
         this.current = element;
+        setVisible(element != null);
         if (element == null) {
             nameField.setText("");
             idField.setText("");
             descField.setText("");
             zIndexField.setText("");
-            setBackground(null);
+            widthField.setText("");
+            heightField.setText("");
+            borderWidthField.setText("");
+            shadowEnableBox.setSelected(false);
+            shadowOffsetXField.setText("");
+            shadowOffsetYField.setText("");
+            shadowBlurField.setText("");
+            fontBox.setSelectedItem(null);
+            textSizeField.setText("");
+            alignBox.setSelectedItem(TextElement.TextAlignment.LEFT);
+            textOptions.setVisible(false);
             return;
         }
-        nameField.setText(element.getElementName());
-        idField.setText(element.getElementId());
-        descField.setText(element.getDescription());
-        zIndexField.setText(String.valueOf(element.getZIndex()));
-        setBackground(element.getBackgroundColor());
+        textOptions.setVisible(element.getType() == ElementTypes.TEXT || element.getType() == ElementTypes.BUTTON);
+        refresh();
+    }
+
+    public void refresh() {
+        if (current == null) return;
+        nameField.setText(current.getElementName());
+        idField.setText(current.getElementId());
+        descField.setText(current.getDescription());
+        zIndexField.setText(String.valueOf(current.getZIndex()));
+        widthField.setText(String.valueOf(current.getModel().getWidth()));
+        heightField.setText(String.valueOf(current.getModel().getHeight()));
+        borderWidthField.setText(String.valueOf(current.getModel().getBorderWidth()));
+        shadowEnableBox.setSelected(current.getModel().isShadowEnabled());
+        shadowOffsetXField.setText(String.valueOf(current.getModel().getShadowOffsetX()));
+        shadowOffsetYField.setText(String.valueOf(current.getModel().getShadowOffsetY()));
+        shadowBlurField.setText(String.valueOf(current.getModel().getShadowBlur()));
+        if (current.getModel() instanceof TextElement) {
+            TextElement t = (TextElement) current.getModel();
+            fontBox.setSelectedItem(t.getFont());
+            textSizeField.setText(String.valueOf(t.getFontSize()));
+            alignBox.setSelectedItem(t.getAlignment());
+        }
     }
 
     private void apply() {
@@ -69,11 +165,23 @@ public class PropertyPanel extends JPanel {
         current.setElementName(nameField.getText());
         current.setElementId(idField.getText());
         current.setDescription(descField.getText());
-        try {
-            int z = Integer.parseInt(zIndexField.getText());
-            current.setZIndex(z);
-        } catch (NumberFormatException ignored) {
+        try { current.setZIndex(Integer.parseInt(zIndexField.getText())); } catch (NumberFormatException ignored) {}
+        try { current.getModel().setWidth(Integer.parseInt(widthField.getText())); } catch (NumberFormatException ignored) {}
+        try { current.getModel().setHeight(Integer.parseInt(heightField.getText())); } catch (NumberFormatException ignored) {}
+        try { current.getModel().setBorderWidth(Integer.parseInt(borderWidthField.getText())); } catch (NumberFormatException ignored) {}
+        current.getModel().setShadowEnabled(shadowEnableBox.isSelected());
+        try { current.getModel().setShadowOffsetX(Integer.parseInt(shadowOffsetXField.getText())); } catch (NumberFormatException ignored) {}
+        try { current.getModel().setShadowOffsetY(Integer.parseInt(shadowOffsetYField.getText())); } catch (NumberFormatException ignored) {}
+        try { current.getModel().setShadowBlur(Integer.parseInt(shadowBlurField.getText())); } catch (NumberFormatException ignored) {}
+        if (current.getModel() instanceof TextElement) {
+            TextElement t = (TextElement) current.getModel();
+            t.setFont((String) fontBox.getSelectedItem());
+            try { t.setFontSize(Integer.parseInt(textSizeField.getText())); } catch (NumberFormatException ignored) {}
+            TextElement.TextAlignment al = (TextElement.TextAlignment) alignBox.getSelectedItem();
+            if (al != null) t.setAlignment(al);
         }
+        current.getCanvas().updateElementView(current);
+        current.repaint();
     }
 
     private void chooseColor() {
@@ -81,8 +189,39 @@ public class PropertyPanel extends JPanel {
         Color c = JColorChooser.showDialog(this, "Couleur de fond", current.getBackgroundColor());
         if (c != null) {
             current.setBackgroundColor(c);
-            setBackground(c);
         }
     }
-    
+
+    private void chooseBorderColor() {
+        if (current == null) return;
+        Color c = JColorChooser.showDialog(this, "Couleur bordure", Color.BLACK);
+        if (c != null) {
+            current.getModel().setBorderColor(new fr.hattane.ilias.deseigner.model.utils.ColorValue(c.getRed(), c.getGreen(), c.getBlue()));
+            current.repaint();
+        }
+    }
+
+    private void chooseTextColor() {
+        if (current == null || !(current.getModel() instanceof TextElement)) return;
+        TextElement t = (TextElement) current.getModel();
+        Color c = JColorChooser.showDialog(this, "Couleur texte",
+                new Color(t.getTextColor().getRed(), t.getTextColor().getGreen(), t.getTextColor().getBlue()));
+        if (c != null) {
+            t.setTextColor(new fr.hattane.ilias.deseigner.model.utils.ColorValue(c.getRed(), c.getGreen(), c.getBlue()));
+            current.repaint();
+        }
+    }
+
+    private void chooseShadowColor() {
+        if (current == null) return;
+        Color c = JColorChooser.showDialog(this, "Couleur ombre",
+                new Color(current.getModel().getShadowColor().getRed(), current.getModel().getShadowColor().getGreen(),
+                        current.getModel().getShadowColor().getBlue(),
+                        Math.round(current.getModel().getShadowColor().getAlpha() * 255)));
+        if (c != null) {
+            current.getModel().setShadowColor(new fr.hattane.ilias.deseigner.model.utils.ColorValue(c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha()/255f));
+            current.repaint();
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- Ajout d'un type d'élément `BUTTON` avec fond chaud, texte contrasté et ombre par défaut
- Gestion des bordures et des ombres pour les rectangles et zones de texte, avec édition depuis le panneau de propriétés
- Menu contextuel enrichi pour insérer des boutons et rendu mis à jour pour afficher l'ombre

## Testing
- `mvn -q -e package` *(échoué : Network is unreachable)*
- `find src/main/java -name "*.java" | xargs javac -classpath /root/.local/share/mise/installs/gradle/8.14.3/gradle-8.14.3/lib/gson-2.10.jar`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8c724e08323aa0e4739ecf8c502