### PR TITLE
Improve resizing and property panel behavior

### DIFF
--- a/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/TextElement.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/model/elements/types/TextElement.java
@@ -14,6 +14,8 @@ public class TextElement extends RectangleElement {
     private int fontSize = 14;
     private ColorValue textColor = new ColorValue(0, 0, 0);
     private TextAlignment alignment = TextAlignment.LEFT;
+    private boolean bold = false;
+    private boolean italic = false;
 
     public TextElement(String name, int x, int y, int width, int height) {
         this(name, x, y, width, height, ElementTypes.TEXT);
@@ -54,5 +56,21 @@ public class TextElement extends RectangleElement {
 
     public void setAlignment(TextAlignment alignment) {
         this.alignment = alignment;
+    }
+
+    public boolean isBold() {
+        return bold;
+    }
+
+    public void setBold(boolean bold) {
+        this.bold = bold;
+    }
+
+    public boolean isItalic() {
+        return italic;
+    }
+
+    public void setItalic(boolean italic) {
+        this.italic = italic;
     }
 }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/ProjectEditorPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/ProjectEditorPanel.java
@@ -1,6 +1,7 @@
 package fr.hattane.ilias.deseigner.view.panels;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -14,13 +15,16 @@ public class ProjectEditorPanel extends JPanel {
 	private static final long serialVersionUID = 975617998984467670L;
 	
     private final PropertyPanel propertyPanel = new PropertyPanel();
-    private final JScrollPane propertyScroll = new JScrollPane(propertyPanel);
+    private final JScrollPane propertyScroll = new JScrollPane(propertyPanel,
+            JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
     private ModelCanvas canvas;
     private ProjectModel project;
 
     public ProjectEditorPanel() {
         setLayout(new BorderLayout());
-        propertyScroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        propertyScroll.setPreferredSize(new Dimension(260, 0));
+        propertyScroll.getVerticalScrollBar().setUnitIncrement(16);
         propertyScroll.setVisible(false);
         add(propertyScroll, BorderLayout.EAST);
     }

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ElementView.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ElementView.java
@@ -20,10 +20,9 @@ public class ElementView extends JComponent {
 
     private final RectangleElement model;
     private final ModelCanvas canvas;
-    private String elementId = "";
     private String description = "";
     private int zIndex = 0;
-    private Point dragOffset;
+    private Point lastMouse;
     private boolean selected;
     private ElementTypes type = ElementTypes.RECTANGLE;
     private ResizeDirection resizeDir = ResizeDirection.NONE;
@@ -44,23 +43,23 @@ public class ElementView extends JComponent {
             public void mousePressed(MouseEvent e) {
                 if (SwingUtilities.isLeftMouseButton(e)) {
                     canvas.selectElement(ElementView.this);
-                    dragOffset = e.getPoint();
+                    lastMouse = e.getLocationOnScreen();
                 }
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                dragOffset = null;
+                lastMouse = null;
                 resizeDir = ResizeDirection.NONE;
                 setCursor(Cursor.getDefaultCursor());
             }
 
             @Override
             public void mouseDragged(MouseEvent e) {
-                if (dragOffset == null) return;
+                if (lastMouse == null) return;
                 float scale = canvas.getScale();
-                int dx = Math.round((e.getX() - dragOffset.x) / scale);
-                int dy = Math.round((e.getY() - dragOffset.y) / scale);
+                int dx = Math.round((e.getXOnScreen() - lastMouse.x) / scale);
+                int dy = Math.round((e.getYOnScreen() - lastMouse.y) / scale);
                 if (resizeDir == ResizeDirection.EAST) {
                     model.setWidth(Math.max(1, model.getWidth() + dx));
                 } else if (resizeDir == ResizeDirection.WEST) {
@@ -77,7 +76,7 @@ public class ElementView extends JComponent {
                     model.setX(model.getX() + dx);
                     model.setY(model.getY() + dy);
                 }
-                dragOffset = e.getPoint();
+                lastMouse = e.getLocationOnScreen();
                 canvas.updateElementView(ElementView.this);
                 canvas.refreshPropertyPanel();
             }
@@ -121,11 +120,7 @@ public class ElementView extends JComponent {
     }
 
     public String getElementId() {
-        return elementId;
-    }
-
-    public void setElementId(String elementId) {
-        this.elementId = elementId;
+        return String.valueOf(model.getId());
     }
 
     public String getDescription() {
@@ -142,8 +137,8 @@ public class ElementView extends JComponent {
 
     public void setZIndex(int zIndex) {
         this.zIndex = zIndex;
-        if (getParent() != null) {
-            getParent().setComponentZOrder(this, zIndex);
+        if (canvas != null) {
+            canvas.reorderElements();
         }
     }
 
@@ -194,7 +189,10 @@ public class ElementView extends JComponent {
             TextElement t = (TextElement) model;
             ColorValue tc = t.getTextColor();
             g2.setColor(new Color(tc.getRed(), tc.getGreen(), tc.getBlue()));
-            g2.setFont(new Font(t.getFont(), Font.PLAIN, t.getFontSize()));
+            int style = Font.PLAIN;
+            if (t.isBold()) style |= Font.BOLD;
+            if (t.isItalic()) style |= Font.ITALIC;
+            g2.setFont(new Font(t.getFont(), style, t.getFontSize()));
             FontMetrics fm = g2.getFontMetrics();
             String text = model.getName();
             int textWidth = fm.stringWidth(text);

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ModelCanvas.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ModelCanvas.java
@@ -14,6 +14,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 /**
  * Zone de dessin principale affichant la grille et les éléments.
@@ -45,6 +46,7 @@ public class ModelCanvas extends JPanel {
                 view.setType(el.getType());
                 elements.add(view);
                 add(view);
+                view.setZIndex(elements.size() - 1);
                 updateElementView(view);
             }
         }
@@ -143,8 +145,10 @@ public class ModelCanvas extends JPanel {
         project.getElements().add(rect);
         ElementView el = new ElementView(this, rect);
         el.setType(type);
+        int newZ = elements.stream().mapToInt(ElementView::getZIndex).max().orElse(-1) + 1;
         elements.add(el);
         add(el);
+        el.setZIndex(newZ);
         selectElement(el);
         updateElementView(el);
     }
@@ -179,6 +183,14 @@ public class ModelCanvas extends JPanel {
         for (ElementView el : elements) {
             updateElementView(el);
         }
+    }
+
+    public void reorderElements() {
+        elements.sort(Comparator.comparingInt(ElementView::getZIndex));
+        for (int i = 0; i < elements.size(); i++) {
+            setComponentZOrder(elements.get(i), elements.size() - 1 - i);
+        }
+        repaint();
     }
 
     public void selectElement(ElementView el) {

--- a/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/PropertyPanel.java
+++ b/src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/PropertyPanel.java
@@ -2,6 +2,7 @@ package fr.hattane.ilias.deseigner.view.panels.editor;
 
 import fr.hattane.ilias.deseigner.model.ElementTypes;
 import fr.hattane.ilias.deseigner.model.elements.types.TextElement;
+import fr.hattane.ilias.deseigner.model.utils.ColorValue;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -36,15 +37,18 @@ public class PropertyPanel extends JPanel {
     private final JTextField textSizeField = new JTextField();
     private final JComboBox<TextElement.TextAlignment> alignBox = new JComboBox<>(TextElement.TextAlignment.values());
     private final JButton textColorButton = new JButton("Couleur texte");
+    private final JCheckBox boldBox = new JCheckBox("Gras");
+    private final JCheckBox italicBox = new JCheckBox("Italique");
     private final JPanel textOptions = new JPanel();
     private ElementView current;
 
     public PropertyPanel() {
-        setPreferredSize(new Dimension(220, 0));
+        setPreferredSize(new Dimension(260, 800));
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBorder(new EmptyBorder(10,10,10,10));
 
         addLabeledField("Nom", nameField);
+        idField.setEditable(false);
         addLabeledField("Id", idField);
         addLabeledField("Description", descField);
         addLabeledField("Z-index", zIndexField);
@@ -83,7 +87,16 @@ public class PropertyPanel extends JPanel {
         textOptions.add(alignBox);
         alignBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, alignBox.getPreferredSize().height));
         textOptions.add(Box.createVerticalStrut(8));
+        textOptions.add(boldBox);
+        textOptions.add(italicBox);
+        boldBox.addActionListener(e -> apply());
+        italicBox.addActionListener(e -> apply());
+        textOptions.add(Box.createVerticalStrut(8));
+        textOptions.add(new JLabel("Couleur texte"));
         textColorButton.addActionListener(e -> chooseTextColor());
+        textColorButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, textColorButton.getPreferredSize().height));
+        textColorButton.setBackground(Color.BLACK);
+        textColorButton.setOpaque(true);
         textOptions.add(textColorButton);
         add(textOptions);
         textOptions.setVisible(false);
@@ -94,7 +107,6 @@ public class PropertyPanel extends JPanel {
             @Override public void changedUpdate(DocumentEvent e) { apply(); }
         };
         nameField.getDocument().addDocumentListener(textListener);
-        idField.getDocument().addDocumentListener(textListener);
         descField.getDocument().addDocumentListener(textListener);
 
         FocusAdapter numberFocus = new FocusAdapter() {
@@ -177,13 +189,16 @@ public class PropertyPanel extends JPanel {
             fontBox.setSelectedItem(t.getFont());
             textSizeField.setText(String.valueOf(t.getFontSize()));
             alignBox.setSelectedItem(t.getAlignment());
+            ColorValue tc = t.getTextColor();
+            textColorButton.setBackground(new Color(tc.getRed(), tc.getGreen(), tc.getBlue()));
+            boldBox.setSelected(t.isBold());
+            italicBox.setSelected(t.isItalic());
         }
     }
 
     private void apply() {
         if (current == null) return;
         current.setElementName(nameField.getText());
-        current.setElementId(idField.getText());
         current.setDescription(descField.getText());
         try { current.setZIndex(Integer.parseInt(zIndexField.getText())); } catch (NumberFormatException ignored) {}
         try { current.getModel().setWidth(Integer.parseInt(widthField.getText())); } catch (NumberFormatException ignored) {}
@@ -199,6 +214,8 @@ public class PropertyPanel extends JPanel {
             try { t.setFontSize(Integer.parseInt(textSizeField.getText())); } catch (NumberFormatException ignored) {}
             TextElement.TextAlignment al = (TextElement.TextAlignment) alignBox.getSelectedItem();
             if (al != null) t.setAlignment(al);
+            t.setBold(boldBox.isSelected());
+            t.setItalic(italicBox.isSelected());
         }
         current.getCanvas().updateElementView(current);
         current.repaint();
@@ -228,6 +245,7 @@ public class PropertyPanel extends JPanel {
                 new Color(t.getTextColor().getRed(), t.getTextColor().getGreen(), t.getTextColor().getBlue()));
         if (c != null) {
             t.setTextColor(new fr.hattane.ilias.deseigner.model.utils.ColorValue(c.getRed(), c.getGreen(), c.getBlue()));
+            textColorButton.setBackground(c);
             current.repaint();
         }
     }


### PR DESCRIPTION
## Summary
- Auto-generate element IDs, expose them read-only in the property panel
- Order elements by z-index to control painting depth
- Keep editor enhancements including font styling and color options

## Testing
- `javac -cp src/main/java src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ElementView.java src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/ModelCanvas.java src/main/java/fr/hattane/ilias/deseigner/view/panels/editor/PropertyPanel.java`
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a995d38a908323a037de85dee029fc